### PR TITLE
Support non-existent file with node>=0.12

### DIFF
--- a/test/unit/integration.js
+++ b/test/unit/integration.js
@@ -61,19 +61,21 @@ test('test that the stuff works =)',function(t){
         done();
       },6000);
       
-      fs.open(logFile,'a+',function(err,fd){
-
-        assert.ifError(err);
-        
-        fd1 = fd;
-        
-        var buf = new Buffer('party rockin');
-        
-        // watchFile does not seem to hit imediately for regular empty files.
-        fs.write(fd1,buf,0,buf.length,null,function(err,bytesWritten){
+      // Delay first write by 500ms, greater than watcher's timeoutInterval of 200ms
+      setTimeout(function() {
+        fs.open(logFile,'a+',function(err,fd){
           assert.ifError(err);
+
+          fd1 = fd;
+
+          var buf = new Buffer('party rockin');
+
+          // watchFile does not seem to hit imediately for regular empty files.
+          fs.write(fd1,buf,0,buf.length,null,function(err,bytesWritten){
+            assert.ifError(err);
+          });
         });
-      });
+      }, 500);
     },
     //
     "trigger change expect that it is fired within one second":function(){

--- a/watch.js
+++ b/watch.js
@@ -173,8 +173,9 @@ var WatcherMethods = {
         //no hardlinks left to this file. 
         //or no inode. its unlinked for sure.
         var ino = cur.ino||prev.ino;
-        self.emit('unlink',self.fds[ino].fd,self.fds[ino].getData());
-
+        if (ino && ino in self.fds) {
+          self.emit('unlink',self.fds[ino].fd,self.fds[ino].getData());
+        }
       } else if(!self.fds[cur.ino]){
 
         self._observeInode(cur);


### PR DESCRIPTION
Hi Ryan, here's a possible fix for the problem discussed in #2

The change to the test is to delay the first write to `logFile` until after the first `timeoutInterval` period has passed. This would have caught and therefore should prevent this problem occurring again.

Thank you!
